### PR TITLE
Added AO486 to blacklist

### DIFF
--- a/appsettings-release.json
+++ b/appsettings-release.json
@@ -4,5 +4,5 @@
   "OutputPath": "/media/fat/peek/tabs",
   "PeekPath": "/media/fat/peek/peek",
   "CoreWhiteList": "",
-  "CoreBlackList": "hbmame,mame"
+  "CoreBlackList": "hbmame,mame,AO486"
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -4,5 +4,5 @@
   "OutputPath": "C:\\Users\\Eric\\Downloads\\tabs",
   "PeekPath": "",
   "CoreWhiteList": "NES,SNES",
-  "CoreBlackList": "hbmame,mame"
+  "CoreBlackList": "hbmame,mame,AO486"
 }


### PR DESCRIPTION
AO486 (at least for me, and likely others as well) contains some huge files, causing computing hashes to take forever. Also, peek isn't so useful for AO486 anyway just due to the nature of the core.